### PR TITLE
Add Docker provisioning via Ansible nodejs role

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,13 @@
-FROM inclusivedesign/nodejs:0.10.33
- 
-RUN yum -y install git && \
-yum clean all
- 
-RUN mkdir -p /opt/universal
- 
-# Reduce the number of times 'npm install' is run by copying package.json
-# first and the remaining repository contents later
-COPY package.json /opt/universal/
- 
-WORKDIR /opt/universal
- 
-RUN npm install
- 
-COPY . /opt/universal/
- 
-RUN yum -y install nodejs-grunt-cli && \
-grunt dedupe-infusion && \
-yum -y autoremove nodejs-grunt-cli && \
-yum clean all
- 
-CMD ["/bin/bash"] 
+FROM inclusivedesign/nodejs:0.10.40
+
+WORKDIR /etc/ansible/playbooks
+
+COPY provisioning/* /etc/ansible/playbooks/
+
+ENV INSTALL_DIR=/opt/gpii/node_modules/universal
+
+COPY . $INSTALL_DIR
+
+RUN ansible-playbook docker-build.yml --tags "install,configure"
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ COPY provisioning/* /etc/ansible/playbooks/
 
 ENV INSTALL_DIR=/opt/gpii/node_modules/universal
 
+ENV UNIVERSAL_VARS_FILE=docker-vars.yml
+
 COPY . $INSTALL_DIR
 
-RUN ansible-playbook docker-build.yml --tags "install,configure"
+RUN ansible-playbook playbook.yml --tags "install,configure"
 
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ From the root of the `universal` folder, run the following command:
 #### Running tests using a VM
 A VM can be automatically created using tools provided by the [Prosperity4All Quality Infrastructure](https://github.com/GPII/qi-development-environments/). Please ensure the [requirements](https://github.com/GPII/qi-development-environments/#requirements) have been met. The ``vagrant up`` command can then be used to provision a new VM.
 
-- vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && npm test'
-- vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && node tests/ProductionConfigTests.js'
-- vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && DISPLAY=:0 testem ci --file tests/web/testem_qi.json'
+Following provisioning, tests can be run in the VM from the host system as follows:
+
+- node-based tests: `vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && npm test'`
+- browser-based tests: `vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && DISPLAY=:0 testem ci --file tests/web/testem_qi.json'`
+- production tests: `vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && node tests/ProductionConfigTests.js'`
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ From the root of the `universal` folder, run the following command:
 #### Running tests using a VM
 A VM can be automatically created using tools provided by the [Prosperity4All Quality Infrastructure](https://github.com/GPII/qi-development-environments/). Please ensure the [requirements](https://github.com/GPII/qi-development-environments/#requirements) have been met. The ``vagrant up`` command can then be used to provision a new VM.
 
+- vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && npm test'
+- vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && node tests/ProductionConfigTests.js'
+- vagrant ssh -c 'cd /home/vagrant/sync/node_modules/universal && DISPLAY=:0 testem ci --file tests/web/testem_qi.json'
+
 Usage
 -----
 
@@ -100,4 +104,3 @@ GPII component images can then be built using the Universal image. Here are two 
 
 * https://github.com/gpii-ops/docker-preferences-server/
 * https://github.com/gpii-ops/docker-flow-manager/
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,19 +3,20 @@
 
 require 'yaml'
 
-ansible_vars = YAML.load_file("provisioning/vars.yml")
+common_ansible_vars = YAML.load_file("provisioning/vars.yml")
+vagrant_ansible_vars = YAML.load_file("provisioning/vagrant-vars.yml")
 
-app_name = ansible_vars["nodejs_app_name"]
+app_name = common_ansible_vars["nodejs_app_name"]
 
-app_directory = ansible_vars["nodejs_app_install_dir"]
+app_directory = vagrant_ansible_vars["nodejs_app_install_dir"]
 
-app_start_script = ansible_vars["nodejs_app_start_script"]
+app_start_script = common_ansible_vars["nodejs_app_start_script"]
 
 # Check for the existence of the 'VM_HOST_TCP_PORT' environment variable. If it
 # doesn't exist and 'nodejs_app_tcp_port' is defined in vars.yml then use that
 # port. Failing that use defaults provided in this file.
-host_tcp_port = ENV["VM_HOST_TCP_PORT"] || ansible_vars["nodejs_app_tcp_port"] || 8081
-guest_tcp_port = ansible_vars["nodejs_app_tcp_port"] || 8081
+host_tcp_port = ENV["VM_HOST_TCP_PORT"] || common_ansible_vars["nodejs_app_tcp_port"] || 8081
+guest_tcp_port = common_ansible_vars["nodejs_app_tcp_port"] || 8081
 
 # By default this VM will use 2 processor cores and 2GB of RAM. The 'VM_CPUS' and
 # "VM_RAM" environment variables can be used to change that behaviour.
@@ -60,7 +61,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     sudo ansible-galaxy install -fr #{app_directory}/provisioning/requirements.yml
-    sudo PYTHONUNBUFFERED=1 ansible-playbook #{app_directory}/provisioning/playbook.yml --tags="install,configure"
+    sudo UNIVERSAL_VARS_FILE=vagrant-vars.yml PYTHONUNBUFFERED=1 ansible-playbook #{app_directory}/provisioning/playbook.yml --tags="install,configure"
   SHELL
 
   # Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string

--- a/provisioning/docker-build.yml
+++ b/provisioning/docker-build.yml
@@ -1,9 +1,0 @@
----
-- hosts: localhost
-  user: root
-  connection: local
-  vars_files:
-  - docker-vars.yml
-  roles:
-  - facts
-  - nodejs

--- a/provisioning/docker-build.yml
+++ b/provisioning/docker-build.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  user: root
+  connection: local
+  vars_files:
+  - docker-vars.yml
+  roles:
+  - facts
+  - nodejs

--- a/provisioning/docker-vars.yml
+++ b/provisioning/docker-vars.yml
@@ -1,0 +1,22 @@
+nodejs_app_name: universal
+
+# Currently Node.js 0.10.* is required by Universal
+nodejs_version: 0.10.40
+
+# We load Universal to /opt/gpii/node_modules/{{ nodejs_app_name }} in the Dockerfile
+# And configure the ENV there that we use here
+
+nodejs_app_install_dir: "{{ lookup('env', 'INSTALL_DIR') }}"
+
+nodejs_app_git_clone: false
+
+# Modify this to use a branch other than master
+
+nodejs_app_git_branch: master
+
+nodejs_app_commands:
+  - npm install
+  - grunt dedupe-infusion
+  - npm test
+
+nodejs_app_start_script: gpii.js

--- a/provisioning/docker-vars.yml
+++ b/provisioning/docker-vars.yml
@@ -1,22 +1,11 @@
-nodejs_app_name: universal
-
-# Currently Node.js 0.10.* is required by Universal
-nodejs_version: 0.10.40
-
-# We load Universal to /opt/gpii/node_modules/{{ nodejs_app_name }} in the Dockerfile
-# And configure the ENV there that we use here
-
-nodejs_app_install_dir: "{{ lookup('env', 'INSTALL_DIR') }}"
-
-nodejs_app_git_clone: false
-
-# Modify this to use a branch other than master
-
-nodejs_app_git_branch: master
-
+---
+# Docker-specific variables
 nodejs_app_commands:
   - npm install
   - grunt dedupe-infusion
   - npm test
 
-nodejs_app_start_script: gpii.js
+# We load Universal to /opt/gpii/node_modules/{{ nodejs_app_name }}
+# in the Dockerfile, and configure the ENV there that we use here
+
+nodejs_app_install_dir: "{{ lookup('env', 'INSTALL_DIR') }}"

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -3,9 +3,8 @@
   user: root
 
   vars_files:
-    - vars.yml
+    - "{{ lookup('env', 'UNIVERSAL_VARS_FILE')  | default('vars.yml',true) }}"
 
   roles:
     - facts
     - nodejs
-

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -3,7 +3,11 @@
   user: root
 
   vars_files:
-    - "{{ lookup('env', 'UNIVERSAL_VARS_FILE')  | default('vars.yml',true) }}"
+    # The Dockerfile, Vagrantfile or other means of running the playbook
+    # must set the UNIVERSAL_VARS_FILE variable appropriately for its
+    # environment    
+    - "{{ lookup('env', 'UNIVERSAL_VARS_FILE') }}"
+    - vars.yml
 
   roles:
     - facts

--- a/provisioning/vagrant-vars.yml
+++ b/provisioning/vagrant-vars.yml
@@ -1,0 +1,10 @@
+---
+# Vagrant-specific variables
+nodejs_app_npm_packages:
+  - testem
+
+nodejs_app_commands:
+  - npm install
+  - npm run dedupe-infusion
+
+nodejs_app_install_dir: /home/vagrant/sync/node_modules/universal

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -1,4 +1,6 @@
 ---
+# Common variables for universal shared between both
+# Docker and Vagrant builds
 # Please refer to https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml
 # for documentation related to these variables
 
@@ -12,16 +14,6 @@ nodejs_version: 0.10.40
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 1.4.28
 
-nodejs_app_npm_packages:
-  - testem
-
-nodejs_app_commands:
-  - npm install
-  - npm run dedupe-infusion
-
 nodejs_app_start_script: gpii.js
 
-nodejs_app_install_dir: /home/vagrant/sync/node_modules/universal
-
 nodejs_app_git_clone: false
-


### PR DESCRIPTION
Updates the GPII-1507 code to include Docker image building using the nodejs role.

These changes also align the Vagrant and Docker functionality to:
* use the same playbook
* share common variables where possible

PR'd in this manner not necessarily to get the changes into the GPII-1507 PR, but because the GPII-1536 work depends on GPII-1507 and that PR has not been reviewed yet. Once @avtar and others are in agreement that this approach to aligning Vagrant and Docker build approaches works, I can issue a separate PR.